### PR TITLE
Remove unneeded attr riot-tag

### DIFF
--- a/src/grid2.tag
+++ b/src/grid2.tag
@@ -247,7 +247,7 @@ grid2
 
 
 gridcelltag
-  div(riot-tag="{opts.tag}")
+  div
     <yield />
     
   script(type="text/coffee").


### PR DESCRIPTION
The riot-tag attribute was renamed to data-is in riot@3 -- but in any case it seems like this attr has no function here.  Everything works just as well without it as far as I can tell.