### PR TITLE
For custom tags, the value is now in object.val

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Tags that are passed to the column reference will be passed the following attrib
 |name       | Type  |Description
 |------     |------ |------
 |cell		|object |An object which decribed the grid cell. It containts the keys `left` `top` `width` `active` `tag` `text` `ridx` `col` ridx is the row index, col is the column information you defined in columns including any custom keys you add.
-|value		|string |The value of the field passed in
+|val		|string |The value of the field passed in
 |data       |array  |The data passed into the grid
 
 

--- a/test/grid.coffee
+++ b/test/grid.coffee
@@ -127,6 +127,7 @@ describe 'grid2',->
     riot.update()
     setTimeout =>
       expect(@domnode.querySelectorAll('.testcell').length).to.be.gt(1)
+      expect(@domnode.querySelectorAll('.testcell')[0].textContent).to.equal(griddata[0].first_name)
       done()
 
 


### PR DESCRIPTION
This PR has a documentation fix in the README, and also adds an expectation to the custom-tag test to verify that the value is getting set in the DOM correctly.