### PR TITLE
Switch from (deprecated) jade to pug

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "scripts": {
         "test": "karma start",
         "tdd": "npm run watch & karma start --reporters=spec --browsers=Chrome --singleRun=false",
-        "watch": "riot -w src lib --template jade",
-        "build": "riot src lib --template jade"
+        "watch": "riot -w src lib --template pug",
+        "build": "riot src lib --template pug"
     },
     "directories": {
         "lib": "lib"
@@ -23,7 +23,7 @@
                 {
                     "expr": false,
                     "type": "coffee",
-                    "template": "jade",
+                    "template": "pug",
                     "extension": ".tag"
                 }
             ],
@@ -48,7 +48,6 @@
         "coveralls": "^2.11.4",
         "es5-shim": "^4.4.1",
         "istanbul": "^0.3.20",
-        "jade": "^1.9.2",
         "karma": "^0.13.9",
         "karma-browserify": "^4.3.0",
         "karma-chai": "^0.1.0",
@@ -60,6 +59,7 @@
         "karma-sinon": "^1.0.4",
         "karma-spec-reporter": "0.0.20",
         "mocha": "^2.0.1",
+        "pug": "^2.0.0-beta6",
         "riot": "^3.0.2",
         "riotify": "^0.1.2",
         "simulant": "^0.1.5",


### PR DESCRIPTION
This just a change to the tooling.  There’s no impact on the source; it’s not affected by any of the backwards-compatibility issues of pug vs jade

As you know/for posterity the riot deprecation message

```
DEPRECATION WARNING: jade was renamed "pug" - the jade parser will be removed in riot@3.0.0!
```

implies that jade shouldn't be working at all.   Pug is still in beta, but seems to be working fine.

I had tried pug out when I was getting weird errors that I thought may have been related to jade.  Turns out those errors had nothing to do with jade, but along the way I saw that pug worked.  So figured I'd PR it.