### PR TITLE
Use two scroll overlays, for separate fixed- and non-fixed column scrolling

### DIFF
--- a/lib/grid2.js
+++ b/lib/grid2.js
@@ -1,5 +1,5 @@
 
-riot.tag2('grid2', '<div class="gridwrap" riot-style="height:{opts.height}px"> <div class="gridbody" ref="mainbody" riot-style="left:{fixedLeft.width}px;top:{rowHeight}px;bottom:0px"> <div class="fixedLeft" riot-style="transform:translate3d({fixedLeft.left}px,{fixedLeft.top}px,0px);backface-visibility: hidden;width:{fixedLeft.width}px;bottom:1px;z-index:2;"> <gridcelltag class="cell {cell.classes()}" tag="{cell.tag}" data="{parent.opts.data}" no-reorder val="{cell.text}" cell="{cell}" each="{cell in visCells.main}" onclick="{parent.handleClick}" riot-style="position: absolute;left:{cell.left}px;top:{cell.top}px;width:{cell.width}px;height:{parent.rowHeight}px;">{cell.text}</gridcelltag> </div> </div> <div class="gridbody" ref="header" riot-style="height:{rowHeight}px;margin-right:15px"> <div class="header" riot-style="top:0px;left:0px;width:{scrollWidth}px;height:{rowHeight}px"> <div class="headercell {classes}" each="{headers.main}" no-reorder riot-style="transform:translate3d({left}px,0px,0px); backface-visibility: hidden;width:{width}px;height:{rowHeight}px;">{text}</div> </div> </div> <div class="gridbody" riot-style="width:{fixedLeft.width}px;height:{opts.height-2}px"> <div class="fixedLeft" riot-style="transform:translate3d(0px,{fixedLeft.top}px,0px);backface-visibility: hidden;width:{fixedLeft.width}px;bottom:1px;z-index:2;"> <div class="header" riot-style="top:{0 - fixedLeft.top}px;left:0px;width:{fixedLeft.width}px;height:{rowHeight}px"> <div class="headercell {classes}" each="{headers.fixed}" no-reorder riot-style="top:0px;left:{left}px;width:{width}px;height:{rowHeight}px;">{text}</div> </div> <gridcelltag class="cell {cell.classes()}" tag="{cell.tag}" no-reorder data="{parent.opts.data}" val="{cell.text}" cell="{cell}" each="{cell in visCells.fixed}" onclick="{parent.handleClick}" riot-style="position: absolute;left:{cell.left}px;top:{cell.top}px;width:{cell.width}px;height:{parent.rowHeight}px;">{cell.text}</gridcelltag> </div> </div> <div class="gridbody" ref="overlay" onscroll="{scrolling}" riot-style="overflow:auto;left:0px;top:{rowHeight}px;bottom:0px;-webkit-overflow-scrolling: touch;"> <div class="scrollArea" riot-style="background:rgba(0,0,0,0.005);width:{scrollWidth}px;height:{scrollHeight-rowHeight}px;"></div> </div> </div>', 'grid2 { display: block; -webkit-font-smoothing: antialiased; text-rendering: optimizeSpeed; } grid2 .scrollArea { transform: translateZ(0); } grid2 .gridwrap { position: relative; display: block; border: 1px solid #ccc; font-family: sans-serif; font-size: 14px; } grid2 .gridbody { position: absolute; overflow: hidden; top: 0; left: 0; right: 0; bottom: 0; transform: translateZ(0); backface-visibility: hidden; } grid2 .fixedLeft { position: absolute; top: 0; bottom: 0; } grid2 .cell, grid2 .headercell { position: absolute; box-sizing: border-box; padding: 10px 5px; whitespace: no-wrap; overflow: hidden; background: #fff; border: 1px solid #eee; border-width: 0 1px 1px 0; cursor: pointer; } grid2 .cell.active { background: #eee; } grid2 .header { position: absolute; z-index: 1; overflow: hidden; transform: translateZ(0); }', '', function(opts) {
+riot.tag2('grid2', '<div class="gridwrap" riot-style="height:{opts.height}px"> <div class="gridbody" ref="mainbody" riot-style="left:{fixedLeft.width}px;top:{rowHeight}px;bottom:0px"> <div class="fixedLeft" riot-style="transform:translate3d({fixedLeft.left}px,{fixedLeft.top}px,0px);backface-visibility: hidden;width:{fixedLeft.width}px;bottom:1px;z-index:2;"> <gridcelltag class="cell {cell.classes()}" tag="{cell.tag}" data="{parent.opts.data}" no-reorder val="{cell.text}" cell="{cell}" each="{cell in visCells.main}" onclick="{parent.handleClick}" riot-style="position: absolute;left:{cell.left}px;top:{cell.top}px;width:{cell.width}px;height:{parent.rowHeight}px;">{cell.text}</gridcelltag> </div> </div> <div class="gridbody" ref="header" riot-style="height:{rowHeight}px;margin-right:15px"> <div class="header" riot-style="top:0px;left:0px;width:{scrollWidth}px;height:{rowHeight}px"> <div class="headercell {classes}" each="{headers.main}" no-reorder riot-style="transform:translate3d({left}px,0px,0px); backface-visibility: hidden;width:{width}px;height:{rowHeight}px;">{text}</div> </div> </div> <div class="gridbody" riot-style="width:{fixedLeft.width}px;height:{opts.height-2}px"> <div class="fixedLeft" riot-style="transform:translate3d(0px,{fixedLeft.top}px,0px);backface-visibility: hidden;width:{fixedLeft.width}px;bottom:1px;z-index:2;"> <div class="header" riot-style="top:{0 - fixedLeft.top}px;left:0px;width:{fixedLeft.width}px;height:{rowHeight}px"> <div class="headercell {classes}" each="{headers.fixed}" no-reorder riot-style="top:0px;left:{left}px;width:{width}px;height:{rowHeight}px;">{text}</div> </div> <gridcelltag class="cell {cell.classes()}" tag="{cell.tag}" no-reorder data="{parent.opts.data}" val="{cell.text}" cell="{cell}" each="{cell in visCells.fixed}" onclick="{parent.handleClick}" riot-style="position: absolute;left:{cell.left}px;top:{cell.top}px;width:{cell.width}px;height:{parent.rowHeight}px;">{cell.text}</gridcelltag> </div> </div> <div class="gridbody" ref="voverlay" onscroll="{vscrolling}" riot-style="overflow-y:auto;left:0px;top:{rowHeight}px;bottom:0px;-webkit-overflow-scrolling: touch;"> <div class="scrollArea" riot-style="background:rgba(0,0,0,0.005);width:{scrollWidth}px;height:{scrollHeight-rowHeight}px;"></div> </div> <div class="gridbody" ref="overlay" onscroll="{scrolling}" riot-style="overflow:auto;left:{fixedLeft.width}px;top:{rowHeight}px;bottom:0px;-webkit-overflow-scrolling: touch;"> <div class="scrollArea" riot-style="background:rgba(0,0,0,0.005);width:{scrollWidth-fixedLeft.width}px;height:{scrollHeight-rowHeight}px;"></div> </div> </div>', 'grid2 { display: block; -webkit-font-smoothing: antialiased; text-rendering: optimizeSpeed; } grid2 .scrollArea { transform: translateZ(0); } grid2 .gridwrap { position: relative; display: block; border: 1px solid #ccc; font-family: sans-serif; font-size: 14px; } grid2 .gridbody { position: absolute; overflow: hidden; top: 0; left: 0; right: 0; bottom: 0; transform: translateZ(0); backface-visibility: hidden; } grid2 .fixedLeft { position: absolute; top: 0; bottom: 0; } grid2 .cell, grid2 .headercell { position: absolute; box-sizing: border-box; padding: 10px 5px; whitespace: no-wrap; overflow: hidden; background: #fff; border: 1px solid #eee; border-width: 0 1px 1px 0; cursor: pointer; } grid2 .cell.active { background: #eee; } grid2 .header { position: absolute; z-index: 1; overflow: hidden; transform: translateZ(0); }', '', function(opts) {
 var calcArea, calcPos, calcVisible, reCalc, reUse;
 
 this.on('before-mount', function() {
@@ -27,6 +27,7 @@ this.on('mount', function() {
   this.gridbody = this.root.querySelectorAll(".gridbody");
   this.pushevents.forEach((function(_this) {
     return function(eventname) {
+      _this.refs.voverlay.addEventListener(eventname, _this.pushThroughEvent);
       return _this.refs.overlay.addEventListener(eventname, _this.pushThroughEvent);
     };
   })(this));
@@ -36,6 +37,7 @@ this.on('mount', function() {
 this.on('before-unmount', function() {
   return this.pushevents.forEach((function(_this) {
     return function(eventname) {
+      _this.refs.voverlay.removeEventListener(eventname, _this.pushThroughEvent);
       return _this.refs.overlay.removeEventListener(eventname, _this.pushThroughEvent);
     };
   })(this));
@@ -45,7 +47,7 @@ this.on('update', function() {
   if (!this.gridbody || !opts.data || !opts.columns) {
     return;
   }
-  if (this.refs.overlay) {
+  if (this.refs.voverlay) {
     this.fixedLeft.left = 0 - this.refs.overlay.scrollLeft;
     this.fixedLeft.top = 0 - this.refs.overlay.scrollTop;
   }
@@ -135,10 +137,10 @@ this.deselect = (function(_this) {
 
 this.pushThroughEvent = (function(_this) {
   return function(e) {
-    var elem, error, event, top;
+    var elem, event, top;
     e.stopPropagation();
     e.preventUpdate = true;
-    top = _this.refs.overlay.scrollTop;
+    top = _this.refs.voverlay.scrollTop;
     try {
       event = new MouseEvent(e.type, e);
     } catch (error) {
@@ -146,12 +148,15 @@ this.pushThroughEvent = (function(_this) {
       event.initMouseEvent(e.type, true, true, window, 0, e.screenX, e.screenY, e.clientX, e.clientY, e.ctrlKey, e.altKey, e.shiftKey, e.metaKey, e.button, e.target);
     }
     e.preventDefault();
+    _this.refs.voverlay.style.display = "none";
     _this.refs.overlay.style.display = "none";
     elem = document.elementFromPoint(e.pageX, e.pageY);
     if (elem != null) {
       elem.dispatchEvent(event);
     }
+    _this.refs.voverlay.style.display = "block";
     _this.refs.overlay.style.display = "block";
+    _this.refs.voverlay.scrollTop = top;
     return _this.refs.overlay.scrollTop = top;
   };
 })(this);
@@ -228,7 +233,16 @@ calcPos = (function(_this) {
 this.scrolling = (function(_this) {
   return function(e) {
     e.preventUpdate = true;
+    _this.refs.voverlay.scrollTop = _this.refs.overlay.scrollTop;
     _this.refs.header.scrollLeft = _this.refs.overlay.scrollLeft;
+    return _this.update();
+  };
+})(this);
+
+this.vscrolling = (function(_this) {
+  return function(e) {
+    e.preventUpdate = true;
+    _this.refs.overlay.scrollTop = _this.refs.voverlay.scrollTop;
     return _this.update();
   };
 })(this);


### PR DESCRIPTION
The vertical-only overlay covers the whole width (so that the scrollbar will be on the right) while the horizontal-and-vertical overlay which is above it only covers the non-fixed columns.  

This seems to work with the example in `test/index.html`, and the existing tests pass.   I haven't added any new tests, though probably should.

Addresses #18